### PR TITLE
Add Gazebo simulation plug-in for IMU and camera modules

### DIFF
--- a/urdf/alphasense_camera_module.urdf.xacro
+++ b/urdf/alphasense_camera_module.urdf.xacro
@@ -33,11 +33,17 @@
       <child link="${name}_link" />
       <xacro:insert_block name="origin"/>
     </joint>
-    <link name="${name}_optical_frame"/>
-    <joint name="${imu_name}_to_${name}_optical_frame" type="fixed">
+    <link name="${name}_frame"/>
+    <joint name="${imu_name}_to_${name}_frame" type="fixed">
       <parent link="${imu_name}"/>
-      <child link="${name}_optical_frame"/>
+      <child link="${name}_frame"/>
       <xacro:insert_block name="imu_cam_origin"/>
+    </joint>
+    <link name="${name}_optical_frame"/>
+    <joint name="${name}_frame_to_${name}_optical_frame" type="fixed">
+      <parent link="${name}_frame"/>
+      <child link="${name}_optical_frame"/>
+      <origin xyz="0 0 0" rpy="0 -${pi/2} 0"/>
     </joint>
   </xacro:macro>
 </robot>

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+<!--
+Copyright 2022 University of Oxford
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+  <!-- Warning: The frame name is not consistent inside the message header and the URDF-->
+  <xacro:macro name="alphasense_cam_gazebo" params="name:=camera
+                                                    camera_link:=alphasense_cam
+                                                    namespace:=alphasense_driver_ros/cam
+                                                    image_topic_name:=''
+                                                    camera_info_topic_name:=camera_info
+                                                    frame_name:=cam_sensor_frame
+                                                    camera_resolution_width:=1440
+                                                    camera_resolution_height:=1080
+                                                    update_rate:=20.0">
+    <gazebo reference="${camera_link}">
+      <sensor type="wideanglecamera" name="${name}">
+        <update_rate>${update_rate}</update_rate>
+        <camera name="${name}">
+          <horizontal_fov>2.20</horizontal_fov>
+          <image>
+            <width>${camera_resolution_width}</width>
+            <height>${camera_resolution_height}</height>
+            <format>BAYER_RGGB8</format>
+          </image>
+          <clip>
+            <near>0.02</near>
+            <far>300</far>
+          </clip>
+          <lens>
+            <type>equidistant</type>
+            <scale_to_hfov>true</scale_to_hfov>
+            <cutoff_angle>1.5707</cutoff_angle>
+            <env_texture_size>1024</env_texture_size>
+          </lens>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+          <alwaysOn>true</alwaysOn>
+          <updateRate>${update_rate}</updateRate>
+          <cameraName>${namespace}</cameraName>
+          <imageTopicName>${image_topic_name}</imageTopicName>
+          <cameraInfoTopicName>${camera_info_topic_name}</cameraInfoTopicName>
+          <frameName>${frame_name}</frameName>
+          <hackBaseline>0.07</hackBaseline>
+          <distortionK1>0.0</distortionK1>
+          <distortionK2>0.0</distortionK2>
+          <distortionK3>0.0</distortionK3>
+          <distortionT1>0.0</distortionT1>
+          <distortionT2>0.0</distortionT2>
+        </plugin>
+      </sensor>
+    </gazebo>
+  </xacro:macro>
+
+  <!-- Warning: The frame name is not consistent inside the message header and the URDF-->
+  <xacro:macro name="alphasense_imu_gazebo" params="name:=imu_sensor
+                                                    imu_link:=alphasense_imu
+                                                    frame_name:=imu_sensor_frame
+                                                    topic_name:=/alphasense_driver_ros/imu
+                                                    update_rate:=400">
+    <gazebo reference="${imu_link}">
+      <gravity>true</gravity>
+      <sensor type="imu" name="${name}">
+        <always_on>true</always_on>
+        <update_rate>${update_rate}</update_rate>
+        <visualize>true</visualize>
+        <topic>/imu</topic>
+        <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
+          <topicName>${topic_name}</topicName>
+          <bodyName>${imu_link}</bodyName>
+          <updateRateHZ>${update_rate}</updateRateHZ>
+          <gaussianNoise>0.0025</gaussianNoise>
+          <xyzOffset>0 0 0</xyzOffset>
+          <rpyOffset>0 0 0</rpyOffset>
+          <frameName>${frame_name}</frameName>
+        </plugin>
+        <pose>0 0 0 0 0 0</pose>
+      </sensor>
+    </gazebo>
+  </xacro:macro>
+
+</robot>


### PR DESCRIPTION
This pull request adds IMU and camera simulation modules for the Alphasense. In the process it was necessary to **rotate the `_optical_frame`** as it was not oriented correctly (see the images below). The old incorrect frame still exists as `_frame`:

| Before | After |
| --- | --- |
| ![Before](https://github.com/ori-drs/alphasense_description/assets/53856473/baa0d050-50ac-40c2-a6bd-74ebc5a7971f) | ![After](https://github.com/ori-drs/alphasense_description/assets/53856473/aeeabfb9-0f35-40cb-9c91-9eeb6fd929a8) |
| ![Before](https://github.com/ori-drs/alphasense_description/assets/53856473/e7857e7e-85fe-409b-8d7c-34e01d167833) | ![After](https://github.com/ori-drs/alphasense_description/assets/53856473/c56fa8fa-7ee9-4923-857e-32d26ae9f6e8) |

There are still some **frame inconsistencies** that persist. The links do not have the same name as the ones published by the Alphasense driver. The Alphasense driver publishes `camX_sensor_frame` where `X` is an integer while the ones inside the URDF are called `cam_front_left`, `cam_front_right`, `cam_side_right`, ... Similarly for the IMU where the driver publishes `imu_sensor_frame` but inside the URDF the corresponding link is called `alphasense_imu`. I do not want to fix these inconsistencies as they might break somebody's URDF that build on them.

The current configuration neglects lens distortion. The reason for this is that the `kalibr` calibration values I have at hand only output distortion values for the equidistant distortion model (see [here](https://github.com/sevensense-robotics/core_research_manual/blob/master/pages/calibration.md)) while Gazebo only supports the radial tangential Brown–Conrady (see [here](http://classic.gazebosim.org/tutorials?tut=camera_distortion&cat=sensors)). More information about this can be found on several issues on `kalibr` (e.g. [#17](https://github.com/ethz-asl/kalibr/issues/17) and [#226](https://github.com/ethz-asl/kalibr/issues/226)). [Somebody posted also a Matlab script](https://github.com/ethz-asl/kalibr/issues/48#issuecomment-220255830) for approximating the equidistant distortion model with the Brown-Conrady (RadTan) distortion model.
